### PR TITLE
Simplify entrypoint.sh

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,11 +3,8 @@ FROM alpine:3.19
 # Install whois package which contains mkpasswd
 RUN apk add --no-cache whois
 
-COPY --chmod=755 entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+# Set mkpasswd as the entrypoint, any CMD or runtime arguments will be passed to it
+ENTRYPOINT ["mkpasswd"]
 
 # Set CMD to an empty array to ensure no additional arguments are passed by default.
-# This allows the entrypoint script to control the arguments fully, providing defaults
-# when no arguments are specified by the user, and respecting any user-provided arguments.
 CMD []

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec mkpasswd --method=sha-512 "$@"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,10 +1,3 @@
 #!/bin/sh
 
-# Check if the first argument is '--method'
-if [ "$1" = "--method" ]; then
-    # If '--method' is the first argument, use all arguments as they are
-    exec mkpasswd "$@"
-else
-    # If '--method' is not the first argument, use the default method and pass all arguments
-    exec mkpasswd --method=sha-512 "$@"
-fi
+exec mkpasswd --method=sha-512 "$@"


### PR DESCRIPTION
Consecutive options override the previous one(s).

```shell
$ mkpasswd --method=sha256crypt --method=md5crypt
Password:
$1$t12AIVB8$q9dfS1PXwX1Ddg1hXwYut.
```
